### PR TITLE
Update reCommonMark to 0.4.0, clean apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get -y install \
   doxygen \
   dvipng \
   graphviz \
-  nginx
+  nginx \
+  nano
 
 # Install readthedocs (bits as of Dec 15 2015)
 RUN mkdir /www
@@ -63,5 +64,9 @@ ENV RTD_PRODUCTION_DOMAIN 'localhost:8000'
 # Set up nginx
 COPY ./files/readthedocs.nginx.conf /etc/nginx/sites-available/readthedocs
 RUN ln -s /etc/nginx/sites-available/readthedocs /etc/nginx/sites-enabled/readthedocs
+
+# Clean Up Apt
+
+RUN apt-get autoremove -y
 
 CMD ["supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ COPY ./files/readthedocs.org-master.tar.gz ./readthedocs.org-master.tar.gz
 RUN tar -zxvf readthedocs.org-master.tar.gz
 RUN mv ./readthedocs.org-master ./readthedocs.org
 
+# Patch tasks.py to use newer recommonmark
+RUN patch ./readthedocs/projects/tasks.py < ./files/tasksrecommonmark.patch
+
 WORKDIR /www/readthedocs.org
 
 # Install the required Python packages
@@ -25,9 +28,6 @@ RUN pip install -r requirements.txt
 
 # Install a higher version of requests to fix an SSL issue
 RUN pip install requests==2.6.0
-
-# Install a different version of recommonmark
-RUN pip install recommonmark==0.4.0
 
 # Override the default settings
 COPY ./files/local_settings.py ./readthedocs/settings/local_settings.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,14 @@ RUN mkdir /www
 WORKDIR /www
 
 COPY ./files/readthedocs.org-master.tar.gz ./readthedocs.org-master.tar.gz
+COPY ./files/tasksrecommonmark.patch ./tasksrecommonmark.patch
 RUN tar -zxvf readthedocs.org-master.tar.gz
+RUN mv ./
 RUN mv ./readthedocs.org-master ./readthedocs.org
 
-# Patch tasks.py to use newer recommonmark
-RUN patch ./readthedocs/projects/tasks.py < ./files/tasksrecommonmark.patch
-
 WORKDIR /www/readthedocs.org
+
+
 
 # Install the required Python packages
 RUN pip install -r requirements.txt
@@ -32,6 +33,10 @@ RUN pip install requests==2.6.0
 
 # Override the default settings
 COPY ./files/local_settings.py ./readthedocs/settings/local_settings.py
+COPY ./files/tasksrecommonmark.patch ./tasksrecommonmark.patch
+
+# Patch tasks.py to use newer recommonmark
+RUN patch ./readthedocs/projects/tasks.py < ./tasksrecommonmark.patch
 
 # Deploy the database
 RUN python ./manage.py migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN pip install -r requirements.txt
 # Install a higher version of requests to fix an SSL issue
 RUN pip install requests==2.6.0
 
+# Install a different version of recommonmark
+RUN pip install recommonmark==0.4.0
+
 # Override the default settings
 COPY ./files/local_settings.py ./readthedocs/settings/local_settings.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ WORKDIR /www
 COPY ./files/readthedocs.org-master.tar.gz ./readthedocs.org-master.tar.gz
 COPY ./files/tasksrecommonmark.patch ./tasksrecommonmark.patch
 RUN tar -zxvf readthedocs.org-master.tar.gz
-RUN mv ./
 RUN mv ./readthedocs.org-master ./readthedocs.org
 
 WORKDIR /www/readthedocs.org

--- a/files/tasksrecommonmark.patch
+++ b/files/tasksrecommonmark.patch
@@ -1,0 +1,11 @@
+--- otasks.py	2016-01-06 16:30:13.744000000 +0000
++++ tasks.py	2016-01-06 16:00:53.824000000 +0000
+@@ -252,7 +252,7 @@
+             'readthedocs-sphinx-ext==0.5.4',
+             'sphinx-rtd-theme==0.1.9',
+             'alabaster>=0.7,<0.8,!=0.7.5',
+-            'recommonmark==0.1.1',
++            'recommonmark==0.4.0',
+         ]
+ 
+         cmd = [


### PR DESCRIPTION
There is an issue with CommonMark 0.6.\* at the moment, mentioned in rtfd/recommonmark#24, which breaks the current docker image. I have made a fork and tested it, this resolves the issue.  I also used autoremove with apt-get, which brings the size of the image up somewhat and confuses me.
